### PR TITLE
remove log_mean_coeff, since it is sufficient in continuous time trai…

### DIFF
--- a/diffusionjax/run_lib.py
+++ b/diffusionjax/run_lib.py
@@ -88,10 +88,10 @@ class State:
 def get_sde(config):
   # Setup SDE
   if config.training.sde.lower() == "vpsde":
-    beta, log_mean_coeff = get_linear_beta_function(
+    beta, mean_coeff = get_linear_beta_function(
       config.model.beta_min, config.model.beta_max
     )
-    return sde_lib.VP(beta=beta, log_mean_coeff=log_mean_coeff)
+    return sde_lib.VP(beta=beta, mean_coeff=mean_coeff)
   elif config.training.sde.lower() == "vesde":
     sigma = get_exponential_sigma_function(config.model.sigma_min, config.model.sigma_max)
     return sde_lib.VE(sigma=sigma)

--- a/diffusionjax/solvers.py
+++ b/diffusionjax/solvers.py
@@ -104,7 +104,7 @@ class Annealed(Solver):
     noise = random.normal(rng, x.shape)
     noise_norm = jnp.linalg.norm(noise.reshape((noise.shape[0], -1)), axis=-1).mean()
     noise_norm = jax.lax.pmean(noise_norm, axis_name="batch")
-    alpha = jnp.exp(2 * self.sde.log_mean_coeff(t))
+    alpha = self.sde.mean_coeff(t)**2
     dt = (self.snr * noise_norm / grad_norm) ** 2 * 2 * alpha
     x_mean = x + batch_mul(grad, dt)
     x = x_mean + batch_mul(2 * dt, noise)

--- a/examples/example.py
+++ b/examples/example.py
@@ -120,10 +120,10 @@ def main(argv):
   if config.training.sde.lower() == "vpsde":
     from diffusionjax.utils import get_linear_beta_function
 
-    beta, log_mean_coeff = get_linear_beta_function(
+    beta, mean_coeff = get_linear_beta_function(
       beta_min=config.model.beta_min, beta_max=config.model.beta_max
     )
-    sde = sde_lib.VP(beta, log_mean_coeff)
+    sde = sde_lib.VP(beta, mean_coeff)
   elif config.training.sde.lower() == "vesde":
     from diffusionjax.utils import get_exponential_sigma_function
 

--- a/examples/example1.py
+++ b/examples/example1.py
@@ -16,6 +16,7 @@ from diffusionjax.utils import (
 from diffusionjax.solvers import EulerMaruyama, Inpainted, Projected
 from diffusionjax.sde import VE
 import numpy as np
+import flax.linen as nn
 import os
 
 # Dependencies:
@@ -39,7 +40,7 @@ class MLP(nn.Module):
   @nn.compact
   def __call__(self, x, t):
     x_shape = x.shape
-    in_size = jnp.prod(x_shape[1:])
+    in_size = np.prod(x_shape[1:])
     n_hidden = 256
     t = t.reshape((t.shape[0], -1))
     x = x.reshape((x.shape[0], -1))  # flatten
@@ -199,7 +200,6 @@ def main():
       score_scaling=True,
       likelihood_weighting=False,
       reduce_mean=True,
-      pointwise_t=False,
     )
 
     # Train with score matching

--- a/test/external/test_benchmark.py
+++ b/test/external/test_benchmark.py
@@ -106,10 +106,10 @@ def main(argv):
   if config.training.sde.lower() == "vpsde":
     from diffusionjax.utils import get_linear_beta_function
 
-    beta, log_mean_coeff = get_linear_beta_function(
+    beta, mean_coeff = get_linear_beta_function(
       config.model.beta_min, config.model.beta_max
     )
-    sde = sde_lib.VP(beta=beta, log_mean_coeff=log_mean_coeff)
+    sde = sde_lib.VP(beta=beta, mean_coeff=mean_coeff)
   elif config.training.sde.lower() == "vesde":
     from diffusionjax.utils import get_exponential_sigma_function
 
@@ -177,6 +177,8 @@ def main(argv):
   std_radii = jnp.std(radii)
 
   # Regression
+  print(mean_radii, expected_mean_radii, "mradii")
+  print(std_radii, expected_std_radii, "mradii")
   assert jnp.isclose(mean_radii, expected_mean_radii)
   assert jnp.isclose(std_radii, expected_std_radii)
   assert jnp.isclose(


### PR DESCRIPTION
…ning to define a mean_coeff. Could also remove betas for continuous time, too, and replace betas with discrete_betas in the solvers, since that would be more compatible with https://arxiv.org/pdf/2102.09672